### PR TITLE
Added compatibility with trusty commission image

### DIFF
--- a/curtin/finalize
+++ b/curtin/finalize
@@ -12,7 +12,7 @@ then
 fi
 
 SCRIPT_DIR=`/usr/bin/dirname $0`
-ABSPATH=`/usr/bin/realpath $SCRIPT_DIR`
+ABSPATH=`/bin/readlink -m $SCRIPT_DIR`
 
 FINALIZE="$ABSPATH/finalize.py"
 


### PR DESCRIPTION
`/usr/bin/realpath` tool does not exist on Ubuntu Trusty and `/bin/readlink` is used instead.